### PR TITLE
fix(migration): move property comments from resource to properties

### DIFF
--- a/SalsaToNew.py
+++ b/SalsaToNew.py
@@ -216,22 +216,12 @@ class Converter:
 
                     tmpOnto["project"]["ontologies"][0]["resources"][-1]["super"] = superMap[resTypeInfo["class"]] # Fill in the super of the ressource
 
-
-
                     for propertyId in resTypeInfo["properties"]:
                         tmpOnto["project"]["ontologies"][0]["resources"][-1]["cardinalities"].append({
                             "propname": propertyId["name"],
                             # "gui_order": "",  # TODO gui_order not yet implemented by knora.
-                            "comments": {},
                             "cardinality": propertyId["occurrence"]
                         })
-                        # Fill in the descriptions
-                        if propertyId["description"] is not None and isinstance(propertyId["description"], list):
-                            for descriptionId in propertyId["description"]:
-                                tmpOnto["project"]["ontologies"][0]["resources"][-1]["cardinalities"][-1][
-                                    "comments"].update({
-                                    detect(descriptionId["description"]): descriptionId["description"]
-                                })
             else:
                 continue
 
@@ -339,6 +329,7 @@ class Converter:
                                 "super": [],
                                 "object": "",
                                 "labels": {},
+                                "comments": {},
                                 "gui_element": "",
                                 "gui_attributes": {}
                             })
@@ -362,6 +353,14 @@ class Converter:
 
                         for property in resTypeInfo["properties"]:
                             if "id" in property and property["id"] == propId:
+                                # fill in the description of the properties as comments
+                                if property["description"] is not None and isinstance(property["description"], list):
+                                     for descriptionId in property["description"]:
+                                         tmpOnto["project"]["ontologies"][0]["properties"][-1]["comments"].update({
+                                             descriptionId["shortname"]: descriptionId["description"]
+                                         })
+
+                                # fill in gui_element
                                 tmpOnto["project"]["ontologies"][0]["properties"][-1]["gui_element"] = guiEleMap[property["gui_name"]] # fill in gui_element
                                 if "attributes" in property and property["attributes"] != "" and property["attributes"] is not None:  # fill in all gui_attributes
                                     finalSplit = []


### PR DESCRIPTION
This PR moves the comments for a property from `fetchResource` to `fetchProperties`. Otherwise schema validation throws an error.

Fixes #8